### PR TITLE
Add wasm plugin benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,9 @@ test/examples: $(foreach var,$(EXAMPLES),test/examples/$(var))
 test/examples/%:
 	$(MAKE) -C $* test
 
+bench:
+	$(MAKE) -C _examples/15_cel_plugin bench
+
 .PHONY: cover-html
 cover-html: test
 	go tool cover -html=cover.out

--- a/_examples/15_cel_plugin/Makefile
+++ b/_examples/15_cel_plugin/Makefile
@@ -16,6 +16,10 @@ lint:
 test:
 	go test -race ./ -count=1
 
+.PHONY: bench
+bench:
+	@go test -bench ./ -run 'BenchmarkFederation' -count=20
+
 .PHONY: grpc-federation/generate
 grpc-federation/generate:
 	@$(GOBIN)/grpc-federation-generator ./proto/federation/federation.proto

--- a/grpc/federation/cel/plugin.go
+++ b/grpc/federation/cel/plugin.go
@@ -31,8 +31,9 @@ type CELPluginConfig struct {
 }
 
 type WasmConfig struct {
-	Path   string
-	Sha256 string
+	Path         string
+	Sha256       string
+	DebugLogging bool
 }
 
 func NewCELPlugin(ctx context.Context, cfg CELPluginConfig) (*CELPlugin, error) {

--- a/grpc/federation/cel/wasm.go
+++ b/grpc/federation/cel/wasm.go
@@ -51,8 +51,14 @@ func NewWasmPlugin(ctx context.Context, wasmCfg WasmConfig) (*WasmPlugin, error)
 	cfg := wazero.NewRuntimeConfig()
 	r := wazero.NewRuntimeWithConfig(ctx, cfg)
 
+	var wasmLogger interface{}
+	if wasmCfg.DebugLogging {
+		wasmLogger = wasmDebugLog
+	} else {
+		wasmLogger = wasmDebugLogNoop
+	}
 	if _, err := r.NewHostModuleBuilder("env").
-		NewFunctionBuilder().WithFunc(wasmDebugLog).Export("grpc_federation_log").
+		NewFunctionBuilder().WithFunc(wasmLogger).Export("grpc_federation_log").
 		Instantiate(ctx); err != nil {
 		return nil, err
 	}
@@ -273,3 +279,5 @@ func wasmDebugLog(_ context.Context, m api.Module, offset, byteCount uint32) {
 	}
 	fmt.Fprintln(os.Stdout, string(buf))
 }
+
+func wasmDebugLogNoop(_ context.Context, m api.Module, offset, byteCount uint32) {}


### PR DESCRIPTION
This refactors `_examples/15_cel_plugin` so that it can be run both as a test and as a benchmark and adds a flag to `WasmConfig` to disable/enable debug logging. The benchmark disables all logging to avoid interfering with the benchmark results. I have also updated the Makefiles to run this benchmark with `make bench`.

I have also added a new test case (`testRegexComplexSuccess`) to evaluate a slightly more involved regex.

The results are encouraging, even if this test is probably dominated by I/O. The following are the results of the baseline compared to the latest pre-release (#124).

```
                              │   before.txt    │                after.txt                │
                              │     sec/op      │     sec/op       vs base                │
Federation/success-10           0.0005831n ± 6%   0.0005571n ± 7%   -4.48% (p=0.032 n=20)
Federation/success_complex-10   0.0005713n ± 5%   0.0005227n ± 8%   -8.51% (p=0.000 n=20)
Federation/failure-10           0.0003323n ± 5%   0.0002961n ± 8%  -10.90% (p=0.000 n=20)
geomean                         0.0004802n        0.0004417n        -8.00%
```

Showing an improvement between 4 and 10% at run-time. Let me know if the approach to configuration works for you, and if the refactoring of the test is fine. I mostly just cobbled this together to make get the results quickly!

